### PR TITLE
Added Offers and Rentals to Spec

### DIFF
--- a/dgoods_spec.md
+++ b/dgoods_spec.md
@@ -144,6 +144,21 @@ Only the token owner can successfully call this function.
 ACTION canceloffer(name owner, vector<uint64_t> tokeninfo_ids);
 ```
 
+**RENTOUTNFT**: Used to rent out non-fungible tokens for a fixed duration.
+The renter takes temporary ownership, but they will not be able to transfer it.
+Only the token owner can successfully call this function and transferable must be true.
+
+```c++
+ACTION rentoutnft(name owner, name renter, uint64_t tokeninfo_id, uint64_t rental_duration, string memo);
+```
+
+**RECLAIMNFT**: Used to reclaim non-fungible tokens after their rental period has expired.
+Only the token owner can successfully call this function, and the rental end time must have passed.
+
+```c++
+ACTION reclaimnft(name owner, vector<uint64_t> tokeninfo_ids)
+```
+
 Dasset Type
 ===========
 
@@ -261,6 +276,21 @@ TABLE offer {
   name to;
 
   uint64_t primary_key() const { return tokeninfo_id; }
+};
+```
+
+Rental Table
+----------------
+
+```c++
+// scope is self
+TABLE rental {
+   uint64_t tokeninfo_id;
+   name owner;
+   name renter;
+   time_point_sec rental_end_time
+
+   uint64_t primary_key() const { return tokeninfo_id; }
 };
 ```
 

--- a/dgoods_spec.md
+++ b/dgoods_spec.md
@@ -121,6 +121,29 @@ may call and transferrable must be true.
 ACTION transfer(name from, name to, name category, name token_name, string quantity, string memo);
 ```
 
+**OFFERNFT**: Used to offer non-fungible tokens. This is an alternative to transfer,
+which requires the receiver to accept the offer, thereby assuming the RAM costs.
+Only the token owner can successfully call this function and transferable must be true.
+
+```c++
+ACTION offernft(name from, name to, vector<uint64_t> tokeninfo_ids, string memo);
+```
+
+**ACCEPTOFFER**: Used to accept an offer of non-fungible tokens.
+After accepting, the receiver assumes the RAM costs of the NFT.
+This can only be called after receiving an offer for those NFTs.
+
+```c++
+ACTION acceptoffer(name accepter, vector<uint64_t> tokeninfo_ids);
+```
+
+**CANCELOFFER**: Used to cancel an offer of non-fungible tokens.
+Only the token owner can successfully call this function.
+
+```c++
+ACTION canceloffer(name owner, vector<uint64_t> tokeninfo_ids);
+```
+
 Dasset Type
 ===========
 
@@ -224,7 +247,21 @@ TABLE tokeninfo {
     
     uint64_t primary_key() const { return id; }
     uint64_t get_owner() const { return owner.value; }
-};   
+}; 
+```
+
+Offer Table
+----------------
+
+```c++
+// scope is self
+TABLE offer {
+  uint64_t tokeninfo_id;
+  name from;
+  name to;
+
+  uint64_t primary_key() const { return tokeninfo_id; }
+};
 ```
 
 Category Table


### PR DESCRIPTION
This pull request adds two very significant features to the spec.

1. Offers allow the ability of transferring NFTs with the receiver confirming and paying for RAM storage.
2. Rentals allow the ability to transfer ownership of an NFT for a fixed-period of time.